### PR TITLE
Initial Enum support

### DIFF
--- a/FSharper.Core/Converter.fs
+++ b/FSharper.Core/Converter.fs
@@ -519,14 +519,14 @@ module FormatOuput =
         |> (fun x -> SynModuleDecl.Types (x, range0))
 
     let toEnum (enum: Enum) =  
-        let createEnumCase name value = 
+        let createEnumCase name synConst = 
             EnumCase(
                 (* SynAttributes *) 
                 SynAttributes.Empty,
                 (* ident:Ident *) 
                 toSingleIdent name,
                 (* SynConst *) 
-                (SynConst.Int32 value),
+                synConst,
                 (* PreXmlDoc *) 
                 PreXmlDoc.Empty,
                 (* range:range *) 
@@ -535,7 +535,10 @@ module FormatOuput =
 
         let enumCases = 
             enum.Members
-            |> List.map (fun (name, value) -> createEnumCase name value)
+            |> List.choose (fun (name, expr) -> 
+                match toSynExpr expr with
+                | SynExpr.Const(synConst, _) -> createEnumCase name synConst |> Some
+                | _ -> None )
 
         let theEnum: SynTypeDefnSimpleRepr = 
             SynTypeDefnSimpleRepr.Enum(

--- a/FSharper.Core/Converter.fs
+++ b/FSharper.Core/Converter.fs
@@ -583,7 +583,7 @@ module FormatOuput =
             )
 
         let info = ComponentInfo (att, [], [], (toIdent enum.Name), PreXmlDocEmpty, false, None, range0)
-        let model = SynTypeDefnRepr.Simple (theEnum,range0)
+        let model = SynTypeDefnRepr.Simple (theEnum, range0)
         let typeDef = TypeDefn (info, model, [], range0) 
         SynModuleDecl.Types ([typeDef], range0)
 

--- a/FSharper.Core/CsharpParser.fs
+++ b/FSharper.Core/CsharpParser.fs
@@ -1144,12 +1144,30 @@ type FSharperTreeBuilder() =
             |> Seq.map this.VisitInterfaceDeclaration
             |> Seq.toList
             |> List.map Structure.Interface
+
+        let enums =
+            node.ChildNodes().OfType<EnumDeclarationSyntax>()
+            |> Seq.map this.VisitEnumDeclaration
+            |> Seq.toList
+            |> List.map Structure.E        
             
         {
             Namespace.Name = node.Name.WithoutTrivia().ToFullString()
-            Namespace.Structures = interfaces @ classes
+            Namespace.Structures = interfaces @ classes @ enums
         } 
 
+    member this.VisitEnumDeclaration(node:EnumDeclarationSyntax) =
+        // TODO: real mapping after initial test passes (Fantomas config tweaking)
+        let enumMembers =
+            [
+                ("None", 0)
+                ("First", 1)
+            ]                           
+        let e = {
+            Enum.Name = node.Identifier.ValueText
+            Members = enumMembers
+        } 
+        e        
 
     member this.VisitInterfaceDeclaration(node:InterfaceDeclarationSyntax) =    
 
@@ -1491,6 +1509,7 @@ type FSharperTreeBuilder() =
             | :? ClassDeclarationSyntax as x -> x |> this.VisitClassDeclaration |> List.map C  |> Structures
             | :? FieldDeclarationSyntax as x -> x |> this.VisitFieldDeclaration |> fieldToClass |> C |> List.singleton |> Structures
             | :? PropertyDeclarationSyntax as x -> x |> this.VisitPropertyDeclaration |>  propertyToClass |> C |> List.singleton |> Structures
+            | :? EnumDeclarationSyntax as x -> x |> this.VisitEnumDeclaration |> E |> List.singleton |> Structures
             //| x -> printfn "Skipping element: %A" <| x.Kind(); Empty
 
         match tree with 

--- a/FSharper.Core/CsharpParser.fs
+++ b/FSharper.Core/CsharpParser.fs
@@ -1157,17 +1157,21 @@ type FSharperTreeBuilder() =
         } 
 
     member this.VisitEnumDeclaration(node:EnumDeclarationSyntax) =
-        // TODO: real mapping after initial test passes (Fantomas config tweaking)
         let enumMembers =
-            [
-                ("None", 0)
-                ("First", 1)
-            ]                           
+             node.Members
+             |> Seq.map this.VisitEnumMemberDeclaration
+             |> Seq.toList                            
         let e = {
             Enum.Name = node.Identifier.ValueText
             Members = enumMembers
         } 
-        e        
+        e   
+        
+    member this.VisitEnumMemberDeclaration(node:EnumMemberDeclarationSyntax) =
+        let nodeValueExpr = CSharpStatementWalker.ParseChsarpNode node.EqualsValue.Value
+        let theMember = EnumMemberValue (node.Identifier.ValueText, nodeValueExpr)
+        theMember 
+        
 
     member this.VisitInterfaceDeclaration(node:InterfaceDeclarationSyntax) =    
 

--- a/FSharper.Core/DomainTypes.fs
+++ b/FSharper.Core/DomainTypes.fs
@@ -395,10 +395,10 @@ type Class = {
 
 type Enum = {
     Name: string
-    Members: (string * EnumMemberValue) list
+    Members: EnumMemberValue list
 }
 //TODO: non-default enum types
-and EnumMemberValue = int
+and EnumMemberValue = string * Expr
 
 type InferfaceMethod = Method of name:Ident * parameters:SynType list
 

--- a/FSharper.Core/DomainTypes.fs
+++ b/FSharper.Core/DomainTypes.fs
@@ -393,6 +393,13 @@ type Class = {
         TypeParameters = []
     }
 
+type Enum = {
+    Name: string
+    Members: (string * EnumMemberValue) list
+}
+//TODO: non-default enum types
+and EnumMemberValue = int
+
 type InferfaceMethod = Method of name:Ident * parameters:SynType list
 
 type UsingStatement = {
@@ -402,6 +409,7 @@ type UsingStatement = {
 type Structure = 
     | Interface of name:Ident * methods:InferfaceMethod list
     | C of Class
+    | E of Enum
 
 type Namespace = {
     Name:string

--- a/FSharper.Core/DomainTypes.fs
+++ b/FSharper.Core/DomainTypes.fs
@@ -396,6 +396,7 @@ type Class = {
 type Enum = {
     Name: string
     Members: EnumMemberValue list
+    Attributes: Attribute list
 }
 //TODO: non-default enum types
 and EnumMemberValue = string * Expr

--- a/FSharper.Core/Translation.fs
+++ b/FSharper.Core/Translation.fs
@@ -658,6 +658,7 @@ module TreeOps =
         let getName = function 
             | C c -> c.Name.Name
             | Interface (name, _) -> name.idText
+            | E e -> e.Name
 
         let names = s |> List.map getName
         let mapping = s |> List.map (fun x -> getName x, x) |> Map.ofList
@@ -679,6 +680,7 @@ module TreeOps =
                 ]   
             | Interface (_, methods) -> 
                 methods |> List.collect (fun (Method (_, types)) -> types |> List.map SynType.getName)
+            | E _ -> []        
 
         let dependencyCount = getDependencies >> List.filter (fun x -> names |> List.contains x)
   

--- a/FSharper.Core/Translation.fs
+++ b/FSharper.Core/Translation.fs
@@ -680,7 +680,7 @@ module TreeOps =
                 ]   
             | Interface (_, methods) -> 
                 methods |> List.collect (fun (Method (_, types)) -> types |> List.map SynType.getName)
-            | E _ -> []        
+            | E _ -> []          
 
         let dependencyCount = getDependencies >> List.filter (fun x -> names |> List.contains x)
   

--- a/FSharper.Tests/EnumTests.fs
+++ b/FSharper.Tests/EnumTests.fs
@@ -1,0 +1,37 @@
+﻿namespace Tests
+
+open NUnit.Framework
+open FSharper.Core
+open FsUnit
+open System
+
+[<TestFixture>]
+type EnumTests () =
+
+    let formatFsharp (s:string) = 
+
+        let indent = "                "
+        s.Split ("\n") |> Array.map (fun x -> if x.StartsWith indent then x.Substring indent.Length else x) |> String.concat "\n"
+        |> (fun s -> 
+            s
+                .Replace("\n    \n", "\n\n")
+                .Replace("\n            \n", "\n\n")
+                .Trim() )
+
+
+    [<Test>]
+    member this.``Simple enum maps directly`` () = 
+        let csharp = 
+             """enum EnumTest { 
+                    None = 0,
+                    First = 1
+                }"""
+    
+        let fsharp = 
+             """type EnumTest =
+                    | None = 0
+                    | First = 1"""
+                   
+        csharp |> Converter.run 
+        |> (fun x -> printfn "%s" x; x)
+        |> should equal (formatFsharp fsharp)

--- a/FSharper.Tests/EnumTests.fs
+++ b/FSharper.Tests/EnumTests.fs
@@ -54,3 +54,35 @@ type EnumTests () =
         csharp |> Converter.run 
         |> (fun x -> printfn "%s" x; x)
         |> should equal (formatFsharp fsharp)
+
+    [<Test>]
+    member this.``Enum with flags attribute`` () = 
+        let csharp = 
+                """[Flags]
+                enum Days 
+                {
+                    None = 0,
+                    Sunday = 1,
+                    Monday = 2,
+                    Tuesday = 4,
+                    Wednesday = 8,
+                    Thursday = 16,
+                    Friday = 32,
+                    Saturday = 64
+                }"""
+            
+        let fsharp = 
+                """[<Flags>]
+                type Days =
+                    | None = 0
+                    | Sunday = 1
+                    | Monday = 2
+                    | Tuesday = 4
+                    | Wednesday = 8
+                    | Thursday = 16
+                    | Friday = 32
+                    | Saturday = 64"""
+                           
+        csharp |> Converter.run 
+        |> (fun x -> printfn "%s" x; x)
+        |> should equal (formatFsharp fsharp)

--- a/FSharper.Tests/EnumTests.fs
+++ b/FSharper.Tests/EnumTests.fs
@@ -86,3 +86,22 @@ type EnumTests () =
         csharp |> Converter.run 
         |> (fun x -> printfn "%s" x; x)
         |> should equal (formatFsharp fsharp)
+
+    [<Test>]
+    member this.``Enum with various whitespace challenges`` () = 
+        let csharp = 
+             """enum EnumTest { 
+                    None     =   0,
+                    Second   =  10,
+                    Final    =  20
+                }"""
+
+        let fsharp = 
+             """type EnumTest =
+                    | None = 0
+                    | Second = 10
+                    | Final = 20"""
+               
+        csharp |> Converter.run 
+        |> (fun x -> printfn "%s" x; x)
+        |> should equal (formatFsharp fsharp)

--- a/FSharper.Tests/EnumTests.fs
+++ b/FSharper.Tests/EnumTests.fs
@@ -35,3 +35,22 @@ type EnumTests () =
         csharp |> Converter.run 
         |> (fun x -> printfn "%s" x; x)
         |> should equal (formatFsharp fsharp)
+
+    [<Test>]
+    member this.``Enum with non-sequential values`` () = 
+        let csharp = 
+                """enum EnumTest { 
+                    None = 0,
+                    Ten = 10,
+                    Twenty = 20
+                }"""
+        
+        let fsharp = 
+                """type EnumTest =
+                    | None = 0
+                    | Ten = 10
+                    | Twenty = 20"""
+                       
+        csharp |> Converter.run 
+        |> (fun x -> printfn "%s" x; x)
+        |> should equal (formatFsharp fsharp)

--- a/FSharper.Tests/EnumTests.fs
+++ b/FSharper.Tests/EnumTests.fs
@@ -8,6 +8,7 @@ open System
 [<TestFixture>]
 type EnumTests () =
 
+ 
     let formatFsharp (s:string) = 
 
         let indent = "                "
@@ -102,6 +103,33 @@ type EnumTests () =
                     | Second = 10
                     | Final = 20"""
                
+        csharp |> Converter.run 
+        |> (fun x -> printfn "%s" x; x)
+        |> should equal (formatFsharp fsharp)
+
+
+    [<Test>]
+    member this.``Enum with flags as hex`` () = 
+        let csharp = 
+                """[Flags]
+                public enum CarOptions
+                {
+                    SunRoof = 0x01,
+                    Spoiler = 0x02,
+                    FogLights = 0x04,
+                    TintedWindows = 0x08,
+                    HeatedSeats = 0x10
+                }"""
+                
+        let fsharp = 
+                """[<Flags>]
+                type CarOptions =
+                    | SunRoof = 1
+                    | Spoiler = 2
+                    | FogLights = 4
+                    | TintedWindows = 8
+                    | HeatedSeats = 16"""
+                               
         csharp |> Converter.run 
         |> (fun x -> printfn "%s" x; x)
         |> should equal (formatFsharp fsharp)

--- a/FSharper.Tests/FSharper.Tests.fsproj
+++ b/FSharper.Tests/FSharper.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="ExtensionMethodsTests.fs" />
     <Compile Include="ClassTests.fs" />
     <Compile Include="FullFileTests.fs" />
+    <Compile Include="EnumTests.fs" />
     <Compile Include="Program.fs" />
     <None Include="app.config" />
   </ItemGroup>


### PR DESCRIPTION
Initial enum support:
[x] attributes
[x] flags
[x] hex
[x] enum whitespace before/after =
Continual features in subsequent PRs:
[ ] types - byte over int
[ ] negative values
[ ] enum other value forms ... binary 0b_0000_0000, etc